### PR TITLE
add linting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Build Status
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, prod ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, prod ]
 
 jobs:
   build:
@@ -28,12 +28,13 @@ jobs:
         pip install flake8 pytest-cov coveralls
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-#    - name: Lint with flake8
-#      run: |
-#        # stop the build if there are Python syntax errors or undefined names
-#        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-#        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with flake8
+      if: github.event_name == 'pull_request'
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest-cov
       run: |

--- a/tests/test_aero_calculator.py
+++ b/tests/test_aero_calculator.py
@@ -1,5 +1,6 @@
 import pytest
 import math
+import logging
 from frispy.model import Model
 from frispy.discs import Discs
 from frispy.aero_calculator import calculate_aero_coefficients


### PR DESCRIPTION
… to:

- Trigger on pushes and pull requests to both the `develop` and `prod` branches.
- Ensure that tests are executed for both `develop` and `prod` environments, depending on the branch that triggered the workflow.
- Enable the `flake8` linting step.
- Configure the linting step to run only on pull requests to catch issues before merging.